### PR TITLE
Update documentation and make unmapping fail silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To disable it:
 
 To enable it by default, add this to your vimrc:
 
-    autocmd VimEnter,BufNewFile,BufReadPost * call HardMode()
+    autocmd VimEnter,BufNewFile,BufReadPost * silent! call HardMode()
 
 You may also wish to add the following to lines to your vimrc:
 

--- a/doc/hardmode.txt
+++ b/doc/hardmode.txt
@@ -23,7 +23,7 @@ To disable it:
 :call EasyMode()
 
 To enable it by default, add this to your |vimrc|:
-autocmd VimEnter,BufNewFile,BufReadPost * call HardMode()
+autocmd VimEnter,BufNewFile,BufReadPost * silent! call HardMode()
 
 You may also wish to add the following to lines to your |vimrc|:
 nnoremap <leader>h <Esc>:call EasyMode()<CR>

--- a/plugin/hardmode.vim
+++ b/plugin/hardmode.vim
@@ -48,40 +48,40 @@ endfun
 fun! EasyMode()
     set backspace=indent,eol,start
 
-    nunmap <buffer> <Left>
-    nunmap <buffer> <Right>
-    nunmap <buffer> <Up>
-    nunmap <buffer> <Down>
-    nunmap <buffer> <PageUp>
-    nunmap <buffer> <PageDown>
+    silent! nunmap <buffer> <Left>
+    silent! nunmap <buffer> <Right>
+    silent! nunmap <buffer> <Up>
+    silent! nunmap <buffer> <Down>
+    silent! nunmap <buffer> <PageUp>
+    silent! nunmap <buffer> <PageDown>
 
-    iunmap <buffer> <Left>
-    iunmap <buffer> <Right>
-    iunmap <buffer> <Up>
-    iunmap <buffer> <Down>
-    iunmap <buffer> <PageUp>
-    iunmap <buffer> <PageDown>
+    silent! iunmap <buffer> <Left>
+    silent! iunmap <buffer> <Right>
+    silent! iunmap <buffer> <Up>
+    silent! iunmap <buffer> <Down>
+    silent! iunmap <buffer> <PageUp>
+    silent! iunmap <buffer> <PageDown>
 
-    vunmap <buffer> <Left>
-    vunmap <buffer> <Right>
-    vunmap <buffer> <Up>
-    vunmap <buffer> <Down>
-    vunmap <buffer> <PageUp>
-    vunmap <buffer> <PageDown>
+    silent! vunmap <buffer> <Left>
+    silent! vunmap <buffer> <Right>
+    silent! vunmap <buffer> <Up>
+    silent! vunmap <buffer> <Down>
+    silent! vunmap <buffer> <PageUp>
+    silent! vunmap <buffer> <PageDown>
 
-    vunmap <buffer> h
-    vunmap <buffer> j
-    vunmap <buffer> k
-    vunmap <buffer> l
-    vunmap <buffer> -
-    vunmap <buffer> +
+    silent! vunmap <buffer> h
+    silent! vunmap <buffer> j
+    silent! vunmap <buffer> k
+    silent! vunmap <buffer> l
+    silent! vunmap <buffer> -
+    silent! vunmap <buffer> +
 
-    nunmap <buffer> h
-    nunmap <buffer> j
-    nunmap <buffer> k
-    nunmap <buffer> l
-    nunmap <buffer> -
-    nunmap <buffer> +
+    silent! nunmap <buffer> h
+    silent! nunmap <buffer> j
+    silent! nunmap <buffer> k
+    silent! nunmap <buffer> l
+    silent! nunmap <buffer> -
+    silent! nunmap <buffer> +
 
     :echo "You are weak..."
 endfun

--- a/plugin/hardmode.vim
+++ b/plugin/hardmode.vim
@@ -2,7 +2,7 @@
 " Author:       Matt Parrott <parrott.matt@gmail.com>
 " Version:      1.0
 
-let g:hardmodemsg = "VIM: hard Mode [ :Easy to exit ]"
+let g:hardmodemsg = "VIM: hard Mode [ ':call EasyMode()' to exit]"
 
 fun! HardMode()
     set backspace=0


### PR DESCRIPTION
Hi,

I like your idea of disabling h,j,k,l etc to break your habits very much :)
However, there are 2 things that I changed:
- The message in HardMode says
  
  "VIM: hard Mode [ :Easy to exit ]"

That command does not (longer) exist, I changed it to

```
"VIM: hard Mode [ ':call EasyMode()' to exit]"
```
- If you press <leader>h while in EasyMode all unmaps fail

So I added "silent!" in front of every unmapping to make it fail silently if no such mapping exists

Regards,
Markus
