### PR TITLE
fixing capitalization typo: HardMode_echo not hardmode_echo

### DIFF
--- a/plugin/hardmode.vim
+++ b/plugin/hardmode.vim
@@ -11,7 +11,7 @@ if !exists('g:HardMode_currentMode')
     let g:HardMode_currentMode = 'easy'
 end
 
-if !exists('g:hardmode_echo')
+if !exists('g:HardMode_echo')
     let g:HardMode_echo = 1
 end
 


### PR DESCRIPTION
Fixing line 14 of plugin/hardmode.vim from

```
if !exists('g:hardmode_echo')
```

to

```
if !exists('g:HardMode_echo')
```
