### PR TITLE
Unmapping line motions while setting Easymode()

### DIFF
--- a/plugin/hardmode.vim
+++ b/plugin/hardmode.vim
@@ -140,6 +140,13 @@ fun! EasyMode()
     silent! nunmap <buffer> -
     silent! nunmap <buffer> +
 
+    " unmap line motions
+    silent! nunmap <buffer> gj
+    silent! nunmap <buffer> gk
+
+    silent! vunmap <buffer> gj
+    silent! vunmap <buffer> gk
+
     let g:HardMode_currentMode = 'easy'
 
     call HardModeEcho(g:HardMode_easymodeMsg)


### PR DESCRIPTION
When trying to go from Hardmode to Easymode, we are not unmapping line
motions. This resolves it. Without this I was unable to use <Up> or <Down> which are mapped to gj and gk. 
